### PR TITLE
Add support for scopes in terraform login service discovery

### DIFF
--- a/tfstd/registry_types.go
+++ b/tfstd/registry_types.go
@@ -20,6 +20,7 @@ type LoginService struct {
 	Authz      string   `json:"authz"`
 	Token      string   `json:"token"`
 	Ports      []int    `json:"ports"`
+	Scopes     []string `json:"scopes"`
 }
 
 // The following three structs represents a response from the module versions endpoint of the registry.


### PR DESCRIPTION
It looks like terraform supports scopes in the login service discovery entry, so add that into the struct.